### PR TITLE
Feature/independent indexing flow

### DIFF
--- a/service/src/main/java/zone/cogni/asquare/service/index/IndexService.java
+++ b/service/src/main/java/zone/cogni/asquare/service/index/IndexService.java
@@ -336,7 +336,7 @@ public class IndexService {
       interruptedGraphs.forEach(graphUri -> log.warn("Graph {} failed timeout", graphUri));
       List<ResourceIndex> tmpResources = resources
               .stream()
-              .filter(resource -> !interruptedGraphs.stream().anyMatch(iterruptedGraph -> resource.getGraph().equals(iterruptedGraph))).collect(Collectors.toList());
+              .filter(resource -> !interruptedGraphs.stream().anyMatch(interruptedGraph -> resource.getGraph().equals(interruptedGraph))).collect(Collectors.toList());
       resources.clear();
       resources.addAll(tmpResources);
     }

--- a/service/src/main/java/zone/cogni/asquare/service/index/IndexService.java
+++ b/service/src/main/java/zone/cogni/asquare/service/index/IndexService.java
@@ -24,7 +24,12 @@ import zone.cogni.sem.jena.model.ResultSetDto;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Added a reindexing flow that is not depending on library-specified task executors and can be ran in sync/async from the code that imports this