### PR TITLE
#T18654 escape new lines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -443,6 +443,10 @@ project('cogni-sem') {
 
     // spring
     api('org.springframework.boot:spring-boot-starter')
+
+    // TESTING
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+    testImplementation project(':cogni-libs')
   }
 }
 

--- a/cogni-sem/src/main/java/zone/cogni/sem/jena/SparqlUtils.java
+++ b/cogni-sem/src/main/java/zone/cogni/sem/jena/SparqlUtils.java
@@ -1,13 +1,16 @@
 package zone.cogni.sem.jena;
 
-import org.apache.commons.lang3.StringUtils;
-
 public enum SparqlUtils {
   ;
 
-  public static String escapeLiteral(String literal) {
-    return StringUtils.replace(literal, "'", "\\'")
-                      .replace("\n", "\\n");
-
+  public static String escapeString(String literal) {
+    return literal.replace("\\", "\\\\") // Escape backslash, needs to be first otherwise it will escape the backslashes of the already escaped literals
+                  .replace("\t", "\\t")  // Escape tab
+                  .replace("\b", "\\b")  // Escape backspace
+                  .replace("\n", "\\n")  // Escape newline
+                  .replace("\r", "\\r")  // Escape carriage return
+                  .replace("\f", "\\f")  // Escape formfeed
+                  .replace("'", "\\'")   // Escape single quote
+                  .replace("\"", "\\\""); // Escape double quote
   }
 }

--- a/cogni-sem/src/main/java/zone/cogni/sem/jena/SparqlUtils.java
+++ b/cogni-sem/src/main/java/zone/cogni/sem/jena/SparqlUtils.java
@@ -6,7 +6,8 @@ public enum SparqlUtils {
   ;
 
   public static String escapeLiteral(String literal) {
-    return StringUtils.replace(literal, "'", "\\'");
+    return StringUtils.replace(literal, "'", "\\'")
+                      .replace("\n", "\\n");
 
   }
 }

--- a/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
+++ b/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
@@ -5,39 +5,54 @@ import org.junit.jupiter.api.Test;
 import zone.cogni.libs.sparqlservice.impl.JenaModelSparqlService;
 
 public class SparqlUtilsTest {
+  private static final String URI = "https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis";
+  private static final String GRAPH_URI = URI + "/graph";
   private final JenaModelSparqlService jenaModelSparqlService = new JenaModelSparqlService();
 
   @Test
   public void test() {
-    initializeSource();
-    confirmResult();
+    testEscape("A\ncomment"); // test newline
+    testEscape("A\\comment"); // test backslash
+    testEscape("A\bcomment"); // test backspace
+    testEscape("I'mAComment"); // test single quote
+    testEscape("A\fcomment"); // test form feed
+    testEscape("A\tcomment");  // test tab
+    testEscape("A\rcomment"); // test carriage return
+    testEscape("com\"ment"); // test double quotes
   }
 
-  private void initializeSource() {
+  private void testEscape(String value) {
+    initializeSource(value);
+    confirmResult(value);
+  }
+
+  private void initializeSource(String value) {
     jenaModelSparqlService.executeUpdateQuery(
       "PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#> " +
       "INSERT DATA { " +
-      "  GRAPH <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis/graph> { " +
-      "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> a jolux:LegalAnalysis. " +
-      "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> jolux:impactFromLegalResourceComment " + "'" + SparqlUtils.escapeLiteral("A\ncomment") + "'" +
+      "  GRAPH <" + GRAPH_URI + "> { " +
+      "    <" + URI + "> a jolux:LegalAnalysis. " +
+      "    <" + URI + "> jolux:impactFromLegalResourceComment \"" + SparqlUtils.escapeString(value) + "\"" +
       "  }" +
       "}"
     );
   }
 
-  private void confirmResult() {
+  private void confirmResult(String value) {
     String query = "PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#>\n" +
                    "SELECT ?comment\n" +
                    "WHERE {\n" +
-                   "  GRAPH <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis/graph> {\n" +
-                   "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> a jolux:LegalAnalysis ;\n" +
-                   "                                                                  jolux:impactFromLegalResourceComment ?comment .\n" +
+                   "  GRAPH <" + GRAPH_URI + "> {\n" +
+                   "    <" + URI + "> a jolux:LegalAnalysis ;\n" +
+                   "                  jolux:impactFromLegalResourceComment ?comment .\n" +
                    "  }\n" +
                    "}";
     jenaModelSparqlService.executeSelectQuery(query, resultSet -> {
-      resultSet.forEachRemaining(result -> Assertions.assertEquals(result.get("comment")
-                                                                         .toString(), "A\ncomment"));
+      resultSet.forEachRemaining(result -> Assertions.assertEquals(value, result.get("comment")
+                                                                                .asLiteral()
+                                                                                .getValue()));
       return null;
     });
+    jenaModelSparqlService.dropGraph(GRAPH_URI);
   }
 }

--- a/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
+++ b/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
@@ -5,11 +5,10 @@ import org.junit.jupiter.api.Test;
 import zone.cogni.libs.sparqlservice.impl.JenaModelSparqlService;
 
 public class SparqlUtilsTest {
-  private JenaModelSparqlService jenaModelSparqlService;
+  private final JenaModelSparqlService jenaModelSparqlService = new JenaModelSparqlService();
 
   @Test
   public void test() {
-    jenaModelSparqlService = new JenaModelSparqlService();
     initializeSource();
     confirmResult();
   }

--- a/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
+++ b/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
@@ -1,0 +1,44 @@
+package zone.cogni.sem.jena;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import zone.cogni.libs.sparqlservice.impl.JenaModelSparqlService;
+
+public class SparqlUtilsTest {
+  private JenaModelSparqlService jenaModelSparqlService;
+
+  @Test
+  public void test() {
+    jenaModelSparqlService = new JenaModelSparqlService();
+    initializeSource();
+    confirmResult();
+  }
+
+  private void initializeSource() {
+    jenaModelSparqlService.executeUpdateQuery(
+      "PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#> " +
+      "INSERT DATA { " +
+      "  GRAPH <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis/graph> { " +
+      "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> a jolux:LegalAnalysis. " +
+      "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> jolux:impactFromLegalResourceComment " + "'" + SparqlUtils.escapeLiteral("A\ncomment") + "'" +
+      "  }" +
+      "}"
+    );
+  }
+
+  private void confirmResult() {
+    String query = "PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#>\n" +
+                   "SELECT ?comment\n" +
+                   "WHERE {\n" +
+                   "  GRAPH <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis/graph> {\n" +
+                   "    <https://fedlex.data.admin.ch/eli/oc/2023/423/legal-analysis> a jolux:LegalAnalysis ;\n" +
+                   "                                                                  jolux:impactFromLegalResourceComment ?comment .\n" +
+                   "  }\n" +
+                   "}";
+    jenaModelSparqlService.executeSelectQuery(query, resultSet -> {
+      resultSet.forEachRemaining(result -> Assertions.assertEquals(result.get("comment")
+                                                                         .toString(), "A\ncomment"));
+      return null;
+    });
+  }
+}

--- a/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
+++ b/cogni-sem/src/test/java/zone/cogni/sem/jena/SparqlUtilsTest.java
@@ -11,28 +11,45 @@ public class SparqlUtilsTest {
 
   @Test
   public void test() {
-    testEscape("A\ncomment"); // test newline
-    testEscape("A\\comment"); // test backslash
-    testEscape("A\bcomment"); // test backspace
-    testEscape("I'mAComment"); // test single quote
-    testEscape("A\fcomment"); // test form feed
-    testEscape("A\tcomment");  // test tab
-    testEscape("A\rcomment"); // test carriage return
-    testEscape("com\"ment"); // test double quotes
+    // test single quotes
+    testEscape("A\ncomment", '\''); // test newline
+    testEscape("A\\comment", '\''); // test backslash
+    testEscape("A\bcomment", '\''); // test backspace
+    testEscape("I'mAComment", '\''); // test single quote
+    testEscape("A\fcomment", '\''); // test form feed
+    testEscape("A\tcomment", '\'');  // test tab
+    testEscape("A\rcomment", '\''); // test carriage return
+    testEscape("com\"ment", '\''); // test double quotes
+    testEscape("This\nis\\A\bco'mment\fthat\ttests\rall\"the\tcases", '\''); // test all cases
+    testEscape("A\\ncomment", '\''); // test mixed case
+    testEscape("A\b\tcomment", '\''); // test mixed case
+
+    // test double quotes
+    testEscape("A\ncomment", '\"'); // test newline
+    testEscape("A\\comment", '\"'); // test backslash
+    testEscape("A\bcomment", '\"'); // test backspace
+    testEscape("I'mAComment", '\"'); // test single quote
+    testEscape("A\fcomment", '\"'); // test form feed
+    testEscape("A\tcomment", '\"');  // test tab
+    testEscape("A\rcomment", '\"'); // test carriage return
+    testEscape("com\"ment", '\"'); // test double quotes
+    testEscape("This\nis\\A\bco'mment\fthat\ttests\rall\"the\tcases", '\"'); // test all cases
+    testEscape("A\\ncomment", '\"'); // test mixed case
+    testEscape("A\b\tcomment", '\"'); // test mixed case
   }
 
-  private void testEscape(String value) {
-    initializeSource(value);
+  private void testEscape(String value, char quote) {
+    initializeSource(value, quote);
     confirmResult(value);
   }
 
-  private void initializeSource(String value) {
+  private void initializeSource(String value, char quote) {
     jenaModelSparqlService.executeUpdateQuery(
       "PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#> " +
       "INSERT DATA { " +
       "  GRAPH <" + GRAPH_URI + "> { " +
       "    <" + URI + "> a jolux:LegalAnalysis. " +
-      "    <" + URI + "> jolux:impactFromLegalResourceComment \"" + SparqlUtils.escapeString(value) + "\"" +
+      "    <" + URI + "> jolux:impactFromLegalResourceComment " + quote + SparqlUtils.escapeString(value) + quote +
       "  }" +
       "}"
     );


### PR DESCRIPTION
#T18654 escape new lines because updateLegalResourceImpactHistoricalImpact-en.sparql in casemates fails for migrated impactToLegalResourceComment or impactFromLegalResourceComment values which contain newLines