### PR TITLE
Feature/elastic components remove query builders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -444,14 +444,10 @@ project('cube') {
   }
 }
 
-// IMPORTANT: license of elasticsearch is not compatible with Apache 2.0 ?!
 project('elastic-components') {
   dependencies {
     // projects
     api project(':service')
-
-    // libs
-    api libs.elasticsearch
   }
 }
 

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
@@ -3,8 +3,6 @@ package zone.cogni.asquare.service.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
@@ -13,22 +11,27 @@ import java.io.IOException;
 public enum ElasticHelper {
   ;
 
-  @Nonnull
-  public static ObjectNode queryBuildToSearchRequest(@Nonnull QueryBuilder queryBuilder) {
-    return queryBuildToSearchRequest(queryBuilder, null);
-  }
-
-  @Nonnull
-  public static ObjectNode queryBuildToSearchRequest(@Nonnull QueryBuilder queryBuilder, @Nullable Integer size) {
-    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(queryBuilder);
-    if (null != size) searchSourceBuilder.size(size);
-    try {
-      return (ObjectNode) new ObjectMapper().readTree(searchSourceBuilder.toString());
-    }
-    catch (IOException e) {
-      throw new RuntimeException("Failed to create ObjectNode from SearchSourceBuilder", e);
-    }
-  }
+  // NOTE: queryBuildToSearchRequest methods have been removed due to Elasticsearch licensing concerns.
+  //
+  // OLD CODE (removed):
+  //   queryBuildToSearchRequest(QueryBuilder queryBuilder)
+  //   queryBuildToSearchRequest(QueryBuilder queryBuilder, Integer size)
+  //
+  // These methods took an Elasticsearch QueryBuilder object, converted it to SearchSourceBuilder,
+  // then serialized it to JSON (ObjectNode). The optional size parameter set the result size.
+  //
+  // MIGRATION GUIDE:
+  // Build your Elasticsearch query JSON directly using Jackson ObjectNode instead of QueryBuilder.
+  //
+  // Example replacement:
+  //   OLD: ElasticHelper.queryBuildToSearchRequest(QueryBuilders.matchQuery("field", "value"), 10)
+  //   NEW: ObjectMapper mapper = new ObjectMapper();
+  //        ObjectNode query = mapper.createObjectNode();
+  //        query.putObject("query").putObject("match").put("field", "value");
+  //        query.put("size", 10);
+  //
+  // This approach avoids the Elasticsearch JAR dependency (Elastic License 2.0) and keeps the
+  // project Apache 2.0 compatible.
 
   @Nonnull
   public static ObjectNode buildFindAllQuery(@Nonnull String typeClassId) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
@@ -3,10 +3,6 @@ package zone.cogni.asquare.service.elasticsearch;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.annotation.Nonnull;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-
-import java.io.IOException;
 
 public enum ElasticHelper {
   ;
@@ -35,14 +31,21 @@ public enum ElasticHelper {
 
   @Nonnull
   public static ObjectNode buildFindAllQuery(@Nonnull String typeClassId) {
-    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(QueryBuilders.termQuery("data.type.keyword", typeClassId))
-            .fetchSource(true);
-    try {
-      return (ObjectNode) new ObjectMapper().readTree(searchSourceBuilder.toString());
-    }
-    catch (IOException e) {
-      throw new RuntimeException("Failed to create ObjectNode from SearchSourceBuilder", e);
-    }
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode root = mapper.createObjectNode();
+
+    // Build query.term["data.type.keyword"]
+    ObjectNode query = root.putObject("query");
+    ObjectNode term = query.putObject("term");
+    ObjectNode termField = term.putObject("data.type.keyword");
+    termField.put("value", typeClassId);
+    termField.put("boost", 1.0);
+
+    // Build _source with empty includes/excludes arrays
+    ObjectNode source = root.putObject("_source");
+    source.putArray("includes");
+    source.putArray("excludes");
+
+    return root;
   }
 }

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
@@ -21,6 +22,19 @@ public enum ElasticHelper {
   public static ObjectNode queryBuildToSearchRequest(@Nonnull QueryBuilder queryBuilder, @Nullable Integer size) {
     SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(queryBuilder);
     if (null != size) searchSourceBuilder.size(size);
+    try {
+      return (ObjectNode) new ObjectMapper().readTree(searchSourceBuilder.toString());
+    }
+    catch (IOException e) {
+      throw new RuntimeException("Failed to create ObjectNode from SearchSourceBuilder", e);
+    }
+  }
+
+  @Nonnull
+  public static ObjectNode buildFindAllQuery(@Nonnull String typeClassId) {
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .query(QueryBuilders.termQuery("data.type.keyword", typeClassId))
+            .fetchSource(true);
     try {
       return (ObjectNode) new ObjectMapper().readTree(searchSourceBuilder.toString());
     }

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/ElasticHelper.java
@@ -7,27 +7,12 @@ import jakarta.annotation.Nonnull;
 public enum ElasticHelper {
   ;
 
-  // NOTE: queryBuildToSearchRequest methods have been removed due to Elasticsearch licensing concerns.
+  // NOTE: queryBuildToSearchRequest(QueryBuilder, Integer size) methods removed due to licensing.
   //
-  // OLD CODE (removed):
-  //   queryBuildToSearchRequest(QueryBuilder queryBuilder)
-  //   queryBuildToSearchRequest(QueryBuilder queryBuilder, Integer size)
+  // These methods converted Elasticsearch QueryBuilder objects to JSON (ObjectNode) via
+  // SearchSourceBuilder serialization. Optionally added a size parameter.
   //
-  // These methods took an Elasticsearch QueryBuilder object, converted it to SearchSourceBuilder,
-  // then serialized it to JSON (ObjectNode). The optional size parameter set the result size.
-  //
-  // MIGRATION GUIDE:
-  // Build your Elasticsearch query JSON directly using Jackson ObjectNode instead of QueryBuilder.
-  //
-  // Example replacement:
-  //   OLD: ElasticHelper.queryBuildToSearchRequest(QueryBuilders.matchQuery("field", "value"), 10)
-  //   NEW: ObjectMapper mapper = new ObjectMapper();
-  //        ObjectNode query = mapper.createObjectNode();
-  //        query.putObject("query").putObject("match").put("field", "value");
-  //        query.put("size", 10);
-  //
-  // This approach avoids the Elasticsearch JAR dependency (Elastic License 2.0) and keeps the
-  // project Apache 2.0 compatible.
+  // Replacement: Build Elasticsearch query JSON directly using Jackson ObjectNode instead.
 
   @Nonnull
   public static ObjectNode buildFindAllQuery(@Nonnull String typeClassId) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
@@ -108,14 +108,22 @@ public class ElasticsearchAccessService implements ElasticAccessService {
 
   @Override
   public List<? extends TypedResource> findAll(ApplicationProfile.Type type) {
-    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(QueryBuilders.termQuery("data.type.keyword", type.getClassId()))
-            .fetchSource(true);
-
-    ObjectNode searchRequestBody = toObjectNode(searchSourceBuilder);
+    ObjectNode searchRequestBody = buildFindAllQuery(type.getClassId());
     ObjectNode searchResponseBody = elasticStore.search(indexName, searchRequestBody);
 
     return getTypedResourcesFrom(searchResponseBody);
+  }
+
+  /**
+   * Builds the Elasticsearch query for finding all resources of a specific type.
+   * Package-private for testing.
+   */
+  ObjectNode buildFindAllQuery(String typeClassId) {
+    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .query(QueryBuilders.termQuery("data.type.keyword", typeClassId))
+            .fetchSource(true);
+
+    return toObjectNode(searchSourceBuilder);
   }
 
   private List<? extends TypedResource> getTypedResourcesFrom(ObjectNode searchResponseBody) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.vavr.control.Try;
 import org.apache.jena.rdf.model.Resource;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -129,16 +128,6 @@ public class ElasticsearchAccessService implements ElasticAccessService {
                          .withApplicationView(new ApplicationView(this, applicationProfile))
                          .withJsonRoot(jsonRoot)
                          .get();
-  }
-
-
-  private ObjectNode toObjectNode(SearchSourceBuilder searchSourceBuilder) {
-    try {
-      return (ObjectNode) new ObjectMapper().readTree(searchSourceBuilder.toString());
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public ObjectNode getRawDocument(String id) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessService.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.vavr.control.Try;
 import org.apache.jena.rdf.model.Resource;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,12 +16,13 @@ import org.springframework.context.annotation.Scope;
 import zone.cogni.asquare.access.AccessType;
 import zone.cogni.asquare.access.ApplicationView;
 import zone.cogni.asquare.access.ElasticAccessService;
-import zone.cogni.asquare.service.elasticsearch.Params;
 import zone.cogni.asquare.access.simplerdf.RdfResource;
 import zone.cogni.asquare.applicationprofile.model.basic.ApplicationProfile;
 import zone.cogni.asquare.edit.DeltaResource;
 import zone.cogni.asquare.rdf.RdfValue;
 import zone.cogni.asquare.rdf.TypedResource;
+import zone.cogni.asquare.service.elasticsearch.ElasticHelper;
+import zone.cogni.asquare.service.elasticsearch.Params;
 import zone.cogni.asquare.service.jsonconversion.JsonConversionFactory;
 import zone.cogni.asquare.triplestore.RdfStoreService;
 import zone.cogni.asquare.web.rest.controller.exceptions.NotFoundException;
@@ -108,22 +108,10 @@ public class ElasticsearchAccessService implements ElasticAccessService {
 
   @Override
   public List<? extends TypedResource> findAll(ApplicationProfile.Type type) {
-    ObjectNode searchRequestBody = buildFindAllQuery(type.getClassId());
+    ObjectNode searchRequestBody = ElasticHelper.buildFindAllQuery(type.getClassId());
     ObjectNode searchResponseBody = elasticStore.search(indexName, searchRequestBody);
 
     return getTypedResourcesFrom(searchResponseBody);
-  }
-
-  /**
-   * Builds the Elasticsearch query for finding all resources of a specific type.
-   * Package-private for testing.
-   */
-  ObjectNode buildFindAllQuery(String typeClassId) {
-    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .query(QueryBuilders.termQuery("data.type.keyword", typeClassId))
-            .fetchSource(true);
-
-    return toObjectNode(searchSourceBuilder);
   }
 
   private List<? extends TypedResource> getTypedResourcesFrom(ObjectNode searchResponseBody) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v7/Elasticsearch7AccessService.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v7/Elasticsearch7AccessService.java
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.base.Preconditions;
 import io.vavr.control.Try;
 import org.apache.jena.rdf.model.Resource;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
@@ -126,16 +124,6 @@ public class Elasticsearch7AccessService implements ElasticAccessService {
                          .withApplicationView(new ApplicationView(this, applicationProfile))
                          .withJsonRoot(jsonRoot)
                          .get();
-  }
-
-
-  private ObjectNode toObjectNode(SearchSourceBuilder searchSourceBuilder) {
-    try {
-      return (ObjectNode) objectMapper.readTree(searchSourceBuilder.toString());
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public ObjectNode getRawDocument(String id) {

--- a/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v7/Elasticsearch7AccessService.java
+++ b/elastic-components/src/main/java/zone/cogni/asquare/service/elasticsearch/v7/Elasticsearch7AccessService.java
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Scope;
 import zone.cogni.asquare.access.AccessType;
 import zone.cogni.asquare.access.ApplicationView;
 import zone.cogni.asquare.access.ElasticAccessService;
+import zone.cogni.asquare.service.elasticsearch.ElasticHelper;
 import zone.cogni.asquare.service.elasticsearch.Params;
 import zone.cogni.asquare.access.simplerdf.RdfResource;
 import zone.cogni.asquare.applicationprofile.model.basic.ApplicationProfile;
@@ -104,11 +105,7 @@ public class Elasticsearch7AccessService implements ElasticAccessService {
 
   @Override
   public List<? extends TypedResource> findAll(ApplicationProfile.Type type) {
-    SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-      .query(QueryBuilders.termQuery("data.type.keyword", type.getClassId()))
-      .fetchSource(true);
-
-    ObjectNode searchRequestBody = toObjectNode(searchSourceBuilder);
+    ObjectNode searchRequestBody = ElasticHelper.buildFindAllQuery(type.getClassId());
     ObjectNode searchResponseBody = elasticStore.search(indexName, searchRequestBody);
 
     return getTypedResourcesFrom(searchResponseBody);

--- a/elastic-components/src/test/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessServiceJsonTest.java
+++ b/elastic-components/src/test/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessServiceJsonTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
+import zone.cogni.asquare.service.elasticsearch.ElasticHelper;
 
 import java.io.IOException;
 
@@ -11,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test to examine the exact JSON output from the current Elasticsearch QueryBuilders implementation.
- * This tests the ACTUAL production code from ElasticsearchAccessService.buildFindAllQuery().
+ * This tests the ACTUAL production code from ElasticHelper.buildFindAllQuery().
  */
 public class ElasticsearchAccessServiceJsonTest {
 
@@ -19,22 +20,13 @@ public class ElasticsearchAccessServiceJsonTest {
 
     @Test
     public void testCurrentQueryBuilderJsonOutput() throws IOException {
-        // Create a minimal service instance (dependencies not needed for buildFindAllQuery)
-        ElasticsearchAccessService service = new ElasticsearchAccessService(
-            "test-index",
-            "test-type",
-            null,  // elasticStore not used by buildFindAllQuery
-            null,  // applicationProfile not used by buildFindAllQuery
-            null   // jsonConversion not used by buildFindAllQuery
-        );
-
-        // Test with actual production method
+        // Test the actual production method
         String typeClassId = "http://example.org/Person";
-        ObjectNode searchRequestBody = service.buildFindAllQuery(typeClassId);
+        ObjectNode searchRequestBody = ElasticHelper.buildFindAllQuery(typeClassId);
 
         // Print the results for visual inspection
         System.out.println("=== CURRENT ELASTICSEARCH V6 QUERY ===");
-        System.out.println("Method: ElasticsearchAccessService.buildFindAllQuery()");
+        System.out.println("Method: ElasticHelper.buildFindAllQuery()");
         System.out.println();
         System.out.println("=== Pretty-Printed JSON ===");
         System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(searchRequestBody));

--- a/elastic-components/src/test/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessServiceJsonTest.java
+++ b/elastic-components/src/test/java/zone/cogni/asquare/service/elasticsearch/v6/ElasticsearchAccessServiceJsonTest.java
@@ -1,0 +1,77 @@
+package zone.cogni.asquare.service.elasticsearch.v6;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test to examine the exact JSON output from the current Elasticsearch QueryBuilders implementation.
+ * This tests the ACTUAL production code from ElasticsearchAccessService.buildFindAllQuery().
+ */
+public class ElasticsearchAccessServiceJsonTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testCurrentQueryBuilderJsonOutput() throws IOException {
+        // Create a minimal service instance (dependencies not needed for buildFindAllQuery)
+        ElasticsearchAccessService service = new ElasticsearchAccessService(
+            "test-index",
+            "test-type",
+            null,  // elasticStore not used by buildFindAllQuery
+            null,  // applicationProfile not used by buildFindAllQuery
+            null   // jsonConversion not used by buildFindAllQuery
+        );
+
+        // Test with actual production method
+        String typeClassId = "http://example.org/Person";
+        ObjectNode searchRequestBody = service.buildFindAllQuery(typeClassId);
+
+        // Print the results for visual inspection
+        System.out.println("=== CURRENT ELASTICSEARCH V6 QUERY ===");
+        System.out.println("Method: ElasticsearchAccessService.buildFindAllQuery()");
+        System.out.println();
+        System.out.println("=== Pretty-Printed JSON ===");
+        System.out.println(objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(searchRequestBody));
+        System.out.println();
+
+        // ASSERTIONS - This documents the expected JSON structure
+        assertNotNull(searchRequestBody, "Search request should not be null");
+
+        // Root level: must have "query" and "_source"
+        assertTrue(searchRequestBody.has("query"), "Root should have 'query' field");
+        assertTrue(searchRequestBody.has("_source"), "Root should have '_source' field");
+
+        // Query structure: query.term["data.type.keyword"]
+        ObjectNode query = (ObjectNode) searchRequestBody.get("query");
+        assertNotNull(query, "Query should not be null");
+        assertTrue(query.has("term"), "Query should have 'term' field");
+
+        ObjectNode term = (ObjectNode) query.get("term");
+        assertNotNull(term, "Term should not be null");
+        assertTrue(term.has("data.type.keyword"), "Term should have 'data.type.keyword' field");
+
+        // The term query value structure
+        ObjectNode termValue = (ObjectNode) term.get("data.type.keyword");
+        assertNotNull(termValue, "Term value should not be null");
+        assertTrue(termValue.has("value"), "Term value should have 'value' field");
+        assertTrue(termValue.has("boost"), "Term value should have 'boost' field");
+        assertEquals(typeClassId, termValue.get("value").asText(), "Term value should match input typeClassId");
+        assertEquals(1.0, termValue.get("boost").asDouble(), 0.001, "Default boost should be 1.0");
+
+        // _source structure: should have includes and excludes arrays
+        ObjectNode source = (ObjectNode) searchRequestBody.get("_source");
+        assertNotNull(source, "_source should not be null");
+        assertTrue(source.has("includes"), "_source should have 'includes' field");
+        assertTrue(source.has("excludes"), "_source should have 'excludes' field");
+        assertInstanceOf(ArrayNode.class, source.get("includes"), "includes should be an array");
+        assertInstanceOf(ArrayNode.class, source.get("excludes"), "excludes should be an array");
+        assertEquals(0, ((ArrayNode) source.get("includes")).size(), "includes array should be empty");
+        assertEquals(0, ((ArrayNode) source.get("excludes")).size(), "excludes array should be empty");
+    }
+}


### PR DESCRIPTION
 ## Remove Elasticsearch dependency from elastic-components module

  ### Summary
  Refactored `elastic-components` module to eliminate Elasticsearch JAR dependency, making it fully Apache 2.0 license compatible. Query JSON is now built directly using Jackson ObjectNode instead of
  Elasticsearch QueryBuilders.

  ### Problem
  The `elastic-components` module depended on `org.elasticsearch:elasticsearch` (Elastic License 2.0 from version 7.11+), which created licensing concerns for the Apache 2.0 licensed project. The
  dependency was only used to build Elasticsearch query JSON via QueryBuilders and SearchSourceBuilder.

  ### Changes

  **1. Refactored query building (`ElasticHelper.java`)**
  - `buildFindAllQuery()` now builds JSON directly with Jackson ObjectNode
  - Removed `queryBuildToSearchRequest()` methods (used Elasticsearch classes)
  - Added migration comments for developers

  **2. Updated AccessService classes**
  - `ElasticsearchAccessService` (v6) and `Elasticsearch7AccessService` (v7) now use shared `ElasticHelper.buildFindAllQuery()`
  - Removed unused `toObjectNode()` helper methods
  - Removed all Elasticsearch imports

  **3. Removed dependency**
  - Removed `api libs.elasticsearch` from `elastic-components` in build.gradle
  - Zero Elasticsearch imports remain in production code

  **4. Added test coverage**
  - Created `ElasticsearchAccessServiceJsonTest` to validate JSON output
  - Test ensures refactored code produces identical Elasticsearch query JSON

  ### Testing
  - ✅ All tests pass
  - ✅ Full clean build successful
  - ✅ Test validates JSON output matches original QueryBuilders output

  ### License Impact
  **elastic-components is now fully Apache 2.0 compatible** - no Elastic License dependencies.
